### PR TITLE
allow space in id and name string

### DIFF
--- a/pphtml.py
+++ b/pphtml.py
@@ -548,7 +548,7 @@ class Pphtml:
         for i, line in enumerate(self.wb):
             if "<meta" in line:
                 continue
-            theids = re.findall(r'id=["\'](.*?)["\']', line)
+            theids = re.findall(r'id\s?=\s?["\'](.*?)["\']', line)
             for theid in theids:
                 id_count += 1
                 # have a link. put it in links map
@@ -565,7 +565,7 @@ class Pphtml:
         for i, line in enumerate(self.wb):
             if "<meta" in line:
                 continue
-            theids = re.findall(r'name=["\'](.*?)["\']', line)
+            theids = re.findall(r'name\s?=\s?["\'](.*?)["\']', line)
             for theid in theids:
                 if theid in self.targets:
                     # the id might already be in the map if it's there from an id=


### PR DESCRIPTION
In actual user HTML, spaces were seen adjacent to the '=' sign. Example: `id= 'name'` 
Though that is unusual, I believe it is legal. This PR allows a space before or after the "=" sign in id or name declaratios.