### PR TITLE
ignore x-ebookmaker-drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.bak
+*.zip
+*.epub
+*.mobi
+*.bk1
+*.bk2
+tmp*.*
+pp_test.*
+.idea/
+.vscode/
+__pycache__/
+doc/
+info/

--- a/pphtml.py
+++ b/pphtml.py
@@ -64,7 +64,7 @@ class Pphtml:
         self.sdir = ""  # to find the images
         self.encoding = ""
         self.NOW = strftime("%A, %Y-%m-%d %H:%M:%S")
-        self.VERSION = "2022.09.23"
+        self.VERSION = "2022.12.28"
         self.onlyfiles = []  # list of files in images folder
         self.filedata = []  # string of image file information
         self.fsizes = []  # image tuple sorted by decreasing size
@@ -1119,7 +1119,7 @@ class Pphtml:
                 if len(s) > 60:
                     r.append("    " + s.strip())
                     s = ""
-            if s != "":
+            if s != "" and key != "x-ebookmaker-drop":
                 r.append("   " + s)
 
         # CSS defined but not used in a class

--- a/pphtml.py
+++ b/pphtml.py
@@ -1108,7 +1108,7 @@ class Pphtml:
         css_used_not_defined = False
         badk = {}
         for key in self.usedcss:
-            if key not in self.udefcss and key != "x-ebookmaker-drop":
+            if key not in self.udefcss and not str(key).startswith("x-ebookmaker"):
                 badk[key] = 1
         if badk:
             css_used_not_defined = True
@@ -1127,7 +1127,7 @@ class Pphtml:
         badk = []
         for key in self.udefcss:
             # exclude x-ebookmaker used in PG projects
-            if key not in self.usedcss and key != "x-ebookmaker":
+            if key not in self.usedcss and not str(key).startswith("x-ebookmaker"):
                 badk.append(key)
         if badk:
             css_defined_not_used = True

--- a/pphtml.py
+++ b/pphtml.py
@@ -1108,7 +1108,7 @@ class Pphtml:
         css_used_not_defined = False
         badk = {}
         for key in self.usedcss:
-            if key not in self.udefcss:
+            if key not in self.udefcss and key != "x-ebookmaker-drop":
                 badk[key] = 1
         if badk:
             css_used_not_defined = True
@@ -1119,7 +1119,7 @@ class Pphtml:
                 if len(s) > 60:
                     r.append("    " + s.strip())
                     s = ""
-            if s != "" and key != "x-ebookmaker-drop":
+            if s != "":
                 r.append("   " + s)
 
         # CSS defined but not used in a class


### PR DESCRIPTION
This is a class name used for special handling by ebookmaker. See DP [Mobile Formats](https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/DP_HTML_Best_Practices/Introductory_Topics/Mobile_Formats). It is confusing to users to report it as a warning. See also Guiguts PR #1061.