### PR TITLE
Detect inline style attributes

### DIFF
--- a/pphtml.py
+++ b/pphtml.py
@@ -1115,6 +1115,24 @@ class Pphtml:
         self.altTags()
         self.lang_check()
         self.headingOutline()
+        self.inlineStyles()
+
+    # --------------------------------------------------------------------------------------
+
+    def inlineStyles(self):
+        """
+        report all HTML tags that use the style attribute (inline styles)
+        """
+        r = []
+
+        for i, line in enumerate(self.wb):
+            for m in re.finditer(r'<(\w+)[^>]*\bstyle\s*=\s*(["\'])(.*?)\2', line):
+                tag = m.group(1)
+                style = m.group(3)
+                r.append("         line {:>5}: &lt;{}&gt; {}".format(i + 1, tag, style))
+
+        r.insert(0, "[info] inline styles found" if r else "[pass] no inline styles found")
+        self.apl(r)
 
     # --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Find and report style attributes found on HTML tags (if any). If none are detected, consider it a [pass]; if any are found, it's only [info].

This ports a check from the legacy pptools site.

**Example outputs:**

No style attributes found:

```
[pass] no inline styles found
```

Style attributes found:

```
[info] inline styles found
         line    99: <div> width: 500px;
         line   120: <div> width: 72px;
         line   122: <div> width: 106px;
         line   132: <div> width: 72px;
         line 12154: <hr> width: 65%;
```
